### PR TITLE
Simplify CI workflow by removing GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [ 
       main, 
-      master, 
-      test-gh-pages-publish  # Special branch for testing GitHub Pages deployment
+      master
     ]
   pull_request:
     branches: [ main, master ]
@@ -61,13 +60,6 @@ jobs:
     permissions:
       contents: read        # Required for actions/checkout
       pull-requests: write  # Required for commenting on PRs
-      pages: write          # Required for GitHub Pages deployment
-      id-token: write       # Required for GitHub Pages deployment (OIDC)
-    env:
-      # DEPLOY_CONDITION controls when GitHub Pages deployment occurs.
-      # Production: main, master branches deploy automatically
-      # Testing: test-gh-pages-publish branch allows safe deployment testing without affecting production
-      DEPLOY_CONDITION: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/test-gh-pages-publish' }}
     steps:
     - uses: actions/checkout@v4
     
@@ -89,22 +81,6 @@ jobs:
         name: coverage-report-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
         path: coverage/
         retention-days: 30
-
-    - name: Setup Pages
-      if: env.DEPLOY_CONDITION == 'true'
-      uses: actions/configure-pages@v4
-
-    - name: Upload Pages artifact
-      if: env.DEPLOY_CONDITION == 'true'
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: coverage
-
-    - name: Deploy to GitHub Pages
-      if: env.DEPLOY_CONDITION == 'true'
-      uses: actions/deploy-pages@v4
-      with:
-        path: coverage
 
     - name: Comment on PR with coverage report location
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
## 🎯 **Overview**
This PR simplifies our CI workflow by removing the GitHub Pages deployment complexity while maintaining all essential testing and coverage functionality.

## 🔄 **Changes Made**
- ❌ **Removed GitHub Pages deployment** - No more publishing to gh-pages
- ❌ **Removed deployment permissions** - No longer need `pages: write` or `id-token: write`
- ❌ **Removed test branch trigger** - `test-gh-pages-publish` no longer needed
- ❌ **Removed deployment environment** - Simplified job configuration
- ✅ **Kept coverage generation** - Still runs with `COVERAGE=true`
- ✅ **Kept artifact upload** - Coverage reports available as downloadable artifacts
- ✅ **Kept PR comments** - Still notifies about coverage report availability

## 📊 **Coverage Reports**
Coverage reports are now available via:
1. **Workflow artifacts** - Download from Actions tab
2. **PR comments** - Automated instructions for accessing reports

## 🚀 **Benefits**
- **Simpler workflow** - Fewer moving parts and dependencies
- **Faster execution** - No deployment steps to slow down CI
- **Reduced permissions** - Enhanced security with minimal required permissions
- **Same functionality** - All testing and coverage analysis preserved

## ✅ **Testing**
- [x] CI workflow runs successfully
- [x] Coverage reports generate correctly
- [x] Artifacts upload properly
- [x] PR comments work as expected